### PR TITLE
Auto-download necessary nltk data and expand code comments

### DIFF
--- a/textsummarizer/nlbasics.py
+++ b/textsummarizer/nlbasics.py
@@ -7,7 +7,7 @@ nltk.download('stopwords')
 nltk.download('averaged_perceptron_tagger')
 nltk.download('wordnet')
 
-# Tokenizing text
+# Tokenizing text, i.e. break up text into lists of words/sentences
 text = input ("Enter your text to tokenize here: ")
 from nltk.tokenize import word_tokenize, sent_tokenize
 
@@ -17,7 +17,7 @@ print(sents)
 words=[word_tokenize(sent) for sent in sents]
 print(words)
 
-# Removing stopwords
+# Removing stopwords, commonly used words like "the", "and", etc.
 from nltk.corpus import stopwords
 from string import punctuation
 
@@ -25,24 +25,30 @@ customStopWords=set(stopwords.words('english')+list(punctuation))
 wordsWOStopwords=[word for word in word_tokenize(text) if word not in customStopWords]
 print(wordsWOStopwords)
 
-#Identifying bigrams
+# Identifying bigrams, groupings of two consecutive words
 from nltk.collocations import *
 bigram_measures = nltk.collocations.BigramAssocMeasures()
 finder = BigramCollocationFinder.from_words(wordsWOStopwords)
 print(finder.ngram_fd.items())
 
-# Stemming
+# Stemming (extract stem of word, e.g. the stem of swimming is swim)
 text2 = input ("Enter your text to stem and identify POS here: ")
 from nltk.stem.lancaster import LancasterStemmer
 st = LancasterStemmer()
 stemmedWords = [st.stem(word) for word in word_tokenize(text2)]
 print(stemmedWords)
 
-# POS Tagging
+# POS (part of speech) tagging
 tagList = nltk.pos_tag(word_tokenize(text2))
 pprint(tagList)
 
 # Disambiguating word meanings
+# Words can mean different things depending on their context, and lesk
+# uses a word's context to determine which definition of the word
+# is being used.
+# You can find a description of the algorithm at
+# http://www.nltk.org/howto/wsd.html
+
 word = input ("Enter your word here: ")
 from nltk.corpus import wordnet as wn
 

--- a/textsummarizer/nlbasics.py
+++ b/textsummarizer/nlbasics.py
@@ -1,6 +1,12 @@
 import nltk
 from pprint import pprint
 
+# Download required nltk data
+nltk.download('punkt')
+nltk.download('stopwords')
+nltk.download('averaged_perceptron_tagger')
+nltk.download('wordnet')
+
 # Tokenizing text
 text = input ("Enter your text to tokenize here: ")
 from nltk.tokenize import word_tokenize, sent_tokenize
@@ -14,6 +20,7 @@ print(words)
 # Removing stopwords
 from nltk.corpus import stopwords
 from string import punctuation
+
 customStopWords=set(stopwords.words('english')+list(punctuation))
 wordsWOStopwords=[word for word in word_tokenize(text) if word not in customStopWords]
 print(wordsWOStopwords)
@@ -38,6 +45,7 @@ pprint(tagList)
 # Disambiguating word meanings
 word = input ("Enter your word here: ")
 from nltk.corpus import wordnet as wn
+
 for ss in wn.synsets(word):
    print(ss, ss.definition())
 

--- a/textsummarizer/tokenizerfunction.py
+++ b/textsummarizer/tokenizerfunction.py
@@ -1,5 +1,9 @@
 import nltk
 
+# Download required nltk data
+nltk.download('punkt')
+nltk.download('stopwords')
+
 text = input ("Enter your text here: ")
 from nltk.tokenize import word_tokenize, sent_tokenize
 


### PR DESCRIPTION
- Added lines that would download the `nltk` data required to run `nlbasics.py` and `tokenizerfunction.py` (the program throws an error for users who haven't yet downloaded the data)
- Expanded upon explanations of code in .py files, as per request on the bulletin board