### PR TITLE
Create .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+#Ignores the annoying .DS_Store file
+.DS_Store


### PR DESCRIPTION
fixed the .DS_Store commit error that came up in class. .DS_Store is a file that tracks the positions of icons and other visual attributes in Mac folders. Hence, it does not need to be tracked in a repository/library since it serves a nonessential function.